### PR TITLE
refactor: 상세 비교 창 비율 개선 및 헤더 개선 #39

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const App: React.FC = () => {
                         <SearchBox onFilter={setFilteredData} />
                         <ChickenTable filteredData={filteredData} />
                     </div>
-                    <div className="lg:py-10 sm:w-full sm:py-5">
+                    <div className="lg:py-10 sm:w-auto sm:py-5 sm:flex-col">
                         <ComparisonTable />
                     </div>
                 </div>

--- a/src/components/Common/Explanation.tsx
+++ b/src/components/Common/Explanation.tsx
@@ -3,7 +3,7 @@ import { GrHelpBook } from "react-icons/gr";
 
 const Explanation: React.FC = () => {
     return (
-        <div className="absolute z-10 p-1 text-sm rounded-md shadow-xl text-chickenFont bg-chickenPoint right-6 top-24 opacity-95">
+        <div className="absolute z-10 p-1 text-sm rounded-md shadow-xl text-chickenFont bg-chickenPoint right-6 top-20 opacity-95">
             <div className="rounded-md bg-chickenBackground">
                 <div className="flex items-center justify-center p-3 text-2xl font-bold border-b-2 border-chickenPoint text-chickenPoint">
                     <GrHelpBook />

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -1,5 +1,5 @@
 import ChickenLabsLogo from "../../assets/imges/ChickenLabsLogo.png"
-import { GrCircleQuestion } from "react-icons/gr";
+import { GoQuestion } from "react-icons/go";
 
 interface HeaderProps {
     onMouseEnter: () => void;
@@ -9,7 +9,7 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ onMouseEnter, onMouseLeave }) => {
     return (
         <div className="w-full border-b-2 border-b-chickenPoint">
-            <div className="flex items-center justify-between p-4 text-3xl text-chickenMain">
+            <div className="flex items-center justify-between px-4 text-3xl text-chickenMain">
                 <div className="flex flex-col items-center">
                     <div className="flex items-center">
                         <a href="/">
@@ -21,7 +21,7 @@ const Header: React.FC<HeaderProps> = ({ onMouseEnter, onMouseLeave }) => {
                         </a>
                     </div>
                 </div>
-                <GrCircleQuestion
+                <GoQuestion
                     className="mr-3 text-4xl rounded-full cursor-pointer text-chickenMain hover:text-white hover:bg-chickenPoint"
                     onMouseEnter={onMouseEnter}
                     onMouseLeave={onMouseLeave}

--- a/src/components/Comparison/ComparisonTable.tsx
+++ b/src/components/Comparison/ComparisonTable.tsx
@@ -23,7 +23,7 @@ const ComparisonTable = () => {
     }
 
     return (
-        <div className="flex flex-col max-w-3xl border-2 bg-chickenBackground rounded-3xl border-chickenPoint whitespace-nowrap text-chickenFont">
+        <div className="flex flex-col max-w-2xl mx-5 border-2 sm:max-w-full bg-chickenBackground rounded-3xl border-chickenPoint whitespace-nowrap text-chickenFont">
             <div className="flex items-center justify-between px-10 font-bold border-b-2 sm:justify-center sm:flex-col border-b-chickenPoint sm:text-sm sm:py-5 sm:px-5">
                 <div className="flex items-center p-2 text-2xl text-chickenPoint">
                     <GiChicken className="text-3xl" />


### PR DESCRIPTION
#39 
-좁은 화면일 때 약 800px~1000px 사이에서 비교 창이 왼쪽으로 치우치는 문제 해결.
<img width="500" alt="스크린샷 2024-07-24 오후 1 53 28" src="https://github.com/user-attachments/assets/ba62bdcf-8c95-4a0a-ac7f-590b137077a4">

---

- 넓은 화면일 때 평균 테이블과 맞닿으면서 비교 창이 화면 밖으로 빠져나가는 문제 해결.
<img width="800" alt="스크린샷 2024-07-24 오후 2 05 59" src="https://github.com/user-attachments/assets/0e3f027e-5011-4180-bda6-4af7e1eb960d">
- 헤더 padding-y 속성 삭제 
- 헤더 물음표 아이콘 기존보다 선이 얇은 아이콘으로 교체.